### PR TITLE
Reload tableView after cell is moved

### DIFF
--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -437,6 +437,7 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
 
 - (void)tableView:(UITableView *)tableView moveRowAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath {
     [_eventDispatcher sendInputEventWithName:@"change" body:@{@"target":self.reactTag, @"sourceIndex":@(sourceIndexPath.row), @"sourceSection": @(sourceIndexPath.section), @"destinationIndex":@(destinationIndexPath.row), @"destinationSection":@(destinationIndexPath.section), @"mode": @"move"}];
+    [self.tableView reloadData];
 }
 
 - (NSIndexPath *)tableView:(UITableView *)tableView targetIndexPathForMoveFromRowAtIndexPath:(NSIndexPath *)sourceIndexPath toProposedIndexPath:(NSIndexPath *)proposedDestinationIndexPath {


### PR DESCRIPTION
Hi @nyura123 thanks for your work getting custom cells into the tableview, it's been very useful.

A problem I ran into was syncing my data on the react side, and getting the tableview to reload.

This is a partial fix. I also had to rig my TableView so that it would rebuild its `sections` array. To do this I set a fake property on it that I linked to a numeric state, when I increment that state it triggers componentWillReceiveProps.

Maybe you'll have some idea of how to solve that in a cleaner way. The reloadData call here gets the tableview to update itself in sync with the data being changed which seems to work even though it might potentially be a race condition with the react data being updated. Another option is to set up a reloadData hook which I also did, but removed it when I found I could just add this line.
