### PR TITLE
Table view cell editing style

### DIFF
--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -437,6 +437,7 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
 
 - (void)tableView:(UITableView *)tableView moveRowAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath {
     [_eventDispatcher sendInputEventWithName:@"change" body:@{@"target":self.reactTag, @"sourceIndex":@(sourceIndexPath.row), @"sourceSection": @(sourceIndexPath.section), @"destinationIndex":@(destinationIndexPath.row), @"destinationSection":@(destinationIndexPath.section), @"mode": @"move"}];
+    [self.tableView reloadData];
 }
 
 - (NSIndexPath *)tableView:(UITableView *)tableView targetIndexPathForMoveFromRowAtIndexPath:(NSIndexPath *)sourceIndexPath toProposedIndexPath:(NSIndexPath *)proposedDestinationIndexPath {

--- a/index.js
+++ b/index.js
@@ -50,6 +50,13 @@ var TableView = React.createClass({
          * @platform ios
          */
         scrollIndicatorInsets: React.EdgeInsetsPropType,
+        tableViewCellEditingStyle: React.PropTypes.number,
+    },
+
+    getDefaultProps() {
+        return {
+            tableViewCellEditingStyle: RNTableViewConsts.CellEditingStyle.Delete,
+        };
     },
 
     getInitialState: function() {
@@ -125,7 +132,7 @@ var TableView = React.createClass({
                     additionalItems={this.state.additionalItems}
                     tableViewStyle={TableView.Consts.Style.Plain}
                     tableViewCellStyle={TableView.Consts.CellStyle.Subtitle}
-                    tableViewCellEditingStyle={TableView.Consts.CellEditingStyle.Delete}
+                    tableViewCellEditingStyle={this.props.tableViewCellEditingStyle}
                     separatorStyle={TableView.Consts.SeparatorStyle.Line}
                     scrollIndicatorInsets={this.props.contentInset}
                     {...this.props}


### PR DESCRIPTION
Finishes work you guys did by exposing a `tableViewCellEditingStyle` prop. Kind of a long prop name.

I didn't update the examples but it can be set like so:

```
var RNTableViewConsts = React.NativeModules.UIManager.RNTableView.Constants;

<TableView tableViewCellEditingStyle={RNTableViewConsts.CellEditingStyle.None} ...
```
