### PR TITLE
Expose TableView reloadData hook

### DIFF
--- a/RNTableView.xcodeproj/project.pbxproj
+++ b/RNTableView.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0808A0331C67E9A60038993A /* RNReactModuleCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 0808A0321C67E9A60038993A /* RNReactModuleCell.m */; };
 		872545E11BAAC85D00889249 /* JSONDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 872545D61BAAC85D00889249 /* JSONDataSource.m */; };
 		872545E21BAAC85D00889249 /* RNCellView.m in Sources */ = {isa = PBXBuildFile; fileRef = 872545D81BAAC85D00889249 /* RNCellView.m */; };
 		872545E31BAAC85D00889249 /* RNCellViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 872545DA1BAAC85D00889249 /* RNCellViewManager.m */; };
@@ -32,6 +33,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0808A0311C67E9A60038993A /* RNReactModuleCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNReactModuleCell.h; sourceTree = "<group>"; };
+		0808A0321C67E9A60038993A /* RNReactModuleCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNReactModuleCell.m; sourceTree = "<group>"; };
 		872545D51BAAC85D00889249 /* JSONDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSONDataSource.h; sourceTree = "<group>"; };
 		872545D61BAAC85D00889249 /* JSONDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSONDataSource.m; sourceTree = "<group>"; };
 		872545D71BAAC85D00889249 /* RNCellView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCellView.h; sourceTree = "<group>"; };
@@ -69,6 +72,8 @@
 		872545D41BAAC85D00889249 /* RNTableView */ = {
 			isa = PBXGroup;
 			children = (
+				0808A0311C67E9A60038993A /* RNReactModuleCell.h */,
+				0808A0321C67E9A60038993A /* RNReactModuleCell.m */,
 				872545D51BAAC85D00889249 /* JSONDataSource.h */,
 				872545D61BAAC85D00889249 /* JSONDataSource.m */,
 				872545D71BAAC85D00889249 /* RNCellView.h */,
@@ -177,6 +182,7 @@
 				872545E31BAAC85D00889249 /* RNCellViewManager.m in Sources */,
 				8799E1E01BF1152400AF9A67 /* RNTableFooterViewManager.m in Sources */,
 				872545E51BAAC85D00889249 /* RNTableViewCell.m in Sources */,
+				0808A0331C67E9A60038993A /* RNReactModuleCell.m in Sources */,
 				8799E1DD1BF114F900AF9A67 /* RNTableFooterView.m in Sources */,
 				8799E1E31BF117F600AF9A67 /* RNTableHeaderView.m in Sources */,
 				8799E1E61BF1181400AF9A67 /* RNTableHeaderViewManager.m in Sources */,

--- a/RNTableView/RNReactModuleCell.h
+++ b/RNTableView/RNReactModuleCell.h
@@ -3,20 +3,6 @@
 
 //Use react-native root views as reusable cells returned from cellForRowAtIndexPath.
 
-/*
- Two react-native changes in RCTRootView.m are needed to allow re-rendering into the same view:
- 
- 1. In initWithBridge:(RCTBridge *)bridge moduleName:(NSString *)moduleName initialProperties:(NSDictionary *)initialProperties:
- if (!_bridge.loading) {
- [self bundleFinishedLoading:_bridge]; //instead of _bridge.batchedBridge
- }
- 
- 2. In setAppProperties:(NSDictionary *)appProperties:
- if (_contentView && _bridge.valid && !_bridge.loading) {
- [self runApplication:_bridge]; //instead of _bridge.batchedBridge
- }
- */
-
 @interface RNReactModuleCell : UITableViewCell {
 }
 

--- a/RNTableView/RNReactModuleCell.h
+++ b/RNTableView/RNReactModuleCell.h
@@ -1,0 +1,27 @@
+
+#import <UIKit/UIKit.h>
+
+//Use react-native root views as reusable cells returned from cellForRowAtIndexPath.
+
+/*
+ Two react-native changes in RCTRootView.m are needed to allow re-rendering into the same view:
+ 
+ 1. In initWithBridge:(RCTBridge *)bridge moduleName:(NSString *)moduleName initialProperties:(NSDictionary *)initialProperties:
+ if (!_bridge.loading) {
+ [self bundleFinishedLoading:_bridge]; //instead of _bridge.batchedBridge
+ }
+ 
+ 2. In setAppProperties:(NSDictionary *)appProperties:
+ if (_contentView && _bridge.valid && !_bridge.loading) {
+ [self runApplication:_bridge]; //instead of _bridge.batchedBridge
+ }
+ */
+
+@interface RNReactModuleCell : UITableViewCell {
+}
+
+- (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier bridge:(RCTBridge*) bridge data:(NSDictionary*)data indexPath:(NSIndexPath*)indexPath reactModule:(NSString*)reactModule;
+
+-(void)setUpAndConfigure:(NSDictionary*)data bridge:(RCTBridge*)bridge indexPath:(NSIndexPath*)indexPath reactModule:(NSString*)reactModule;
+
+@end

--- a/RNTableView/RNReactModuleCell.m
+++ b/RNTableView/RNReactModuleCell.m
@@ -31,6 +31,12 @@
     if (_rootView == nil) {
         //Create the mini react app that will populate our cell. This will be called from cellForRowAtIndexPath
         _rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:reactModule initialProperties:props];
+        NSLog(@"width: %@",data[@"width"]);
+        if (data[@"width"]) {
+            CGRect contentViewFrame = self.contentView.frame;
+            contentViewFrame.size.width = ((NSNumber*)data[@"width"]).floatValue;
+            self.contentView.frame = contentViewFrame;
+        }
         [self.contentView addSubview:_rootView];
         _rootView.frame = self.contentView.frame;
     } else {

--- a/RNTableView/RNReactModuleCell.m
+++ b/RNTableView/RNReactModuleCell.m
@@ -1,0 +1,44 @@
+//
+//  RNReactModuleCell.m
+//  RNTableView
+//
+//  Created by Anna Berman on 2/6/16.
+//  Copyright © 2016 Pavlo Aksonov. All rights reserved.
+//
+
+#import <RCTRootView.h>
+#import "RNReactModuleCell.h"
+
+@implementation RNReactModuleCell {
+    RCTRootView *_rootView;
+}
+
+- (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier bridge:(RCTBridge*) bridge data:(NSDictionary*)data indexPath:(NSIndexPath*)indexPath reactModule:(NSString*)reactModule
+{
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        [self setUpAndConfigure:data bridge:bridge indexPath:indexPath reactModule:reactModule];
+    }
+    return self;
+}
+
+-(NSDictionary*) toProps:(NSDictionary *)data indexPath:(NSIndexPath*)indexPath {
+    return @{@"data":data, @"section":[[NSNumber alloc] initWithLong:indexPath.section], @"row":[[NSNumber alloc] initWithLong:indexPath.row]};
+}
+
+-(void)setUpAndConfigure:(NSDictionary*)data bridge:(RCTBridge*)bridge indexPath:(NSIndexPath*)indexPath reactModule:(NSString*)reactModule{
+    NSDictionary *props = [self toProps:data indexPath:indexPath];
+    if (_rootView == nil) {
+        //Create the mini react app that will populate our cell. This will be called from cellForRowAtIndexPath
+        _rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:reactModule initialProperties:props];
+        [self.contentView addSubview:_rootView];
+        _rootView.frame = self.contentView.frame;
+    } else {
+        //Ask react to re-render us with new data
+        _rootView.appProperties = props;
+    }
+    
+    //The application will be unmounted in javascript when the cell/rootview is destroyed
+}
+
+@end

--- a/RNTableView/RNReactModuleCell.m
+++ b/RNTableView/RNReactModuleCell.m
@@ -31,7 +31,6 @@
     if (_rootView == nil) {
         //Create the mini react app that will populate our cell. This will be called from cellForRowAtIndexPath
         _rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:reactModule initialProperties:props];
-        NSLog(@"width: %@",data[@"width"]);
         if (data[@"width"]) {
             CGRect contentViewFrame = self.contentView.frame;
             contentViewFrame.size.width = ((NSNumber*)data[@"width"]).floatValue;
@@ -45,6 +44,11 @@
     }
     
     //The application will be unmounted in javascript when the cell/rootview is destroyed
+}
+
+-(void)prepareForReuse {
+    [super prepareForReuse];
+    //TODO prevent stale data flickering
 }
 
 @end

--- a/RNTableView/RNTableView.h
+++ b/RNTableView/RNTableView.h
@@ -24,6 +24,7 @@
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher bridge:(RCTBridge*) bridge NS_DESIGNATED_INITIALIZER;
 
+@property (strong, nonatomic) UITableView *tableView;
 @property (nonatomic, copy) NSMutableArray *sections;
 @property (nonatomic, copy) NSArray *additionalItems;
 @property (nonatomic, strong) NSString *json;

--- a/RNTableView/RNTableView.h
+++ b/RNTableView/RNTableView.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 @class RCTEventDispatcher;
+@class RCTBridge;
 
 @protocol RNTableViewDatasource <NSObject>
 
@@ -21,7 +22,7 @@
 
 @interface RNTableView : UIView
 
-- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher bridge:(RCTBridge*) bridge NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, copy) NSMutableArray *sections;
 @property (nonatomic, copy) NSArray *additionalItems;
@@ -58,5 +59,6 @@
 @property (nonatomic) BOOL autoFocus;
 @property (nonatomic) BOOL allowsToggle;
 @property (nonatomic) BOOL allowsMultipleSelection;
+@property (nonatomic) NSString *reactModuleForCell;
 
 @end

--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -74,7 +74,13 @@
     RCTAssertParam(eventDispatcher);
     
     if ((self = [super initWithFrame:CGRectZero])) {
-        _bridge = bridge;
+        
+        //RCTRootView setAppProperties and initWithBridge call "_bridge.batchedBridge" which will return nil because the bridge that gets passed to this constructor is *already* the batched bridge.
+        //So we have to create a separate (parent) _bridge here ourselves.
+        _bridge = [[RCTBridge alloc] initWithBundleURL:bridge.bundleURL
+                                        moduleProvider:nil
+                                         launchOptions:nil];
+        
         _eventDispatcher = eventDispatcher;
         _cellHeight = 44;
         _cells = [NSMutableArray array];

--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -21,7 +21,6 @@
     id<RNTableViewDatasource> datasource;
 }
 @property (strong, nonatomic) NSMutableArray *selectedIndexes;
-@property (strong, nonatomic) UITableView *tableView;
 
 @end
 

--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -15,6 +15,7 @@
 #import "RNCellView.h"
 #import "RNTableFooterView.h"
 #import "RNTableHeaderView.h"
+#import "RNReactModuleCell.h"
 
 @interface RNTableView()<UITableViewDataSource, UITableViewDelegate> {
     id<RNTableViewDatasource> datasource;
@@ -25,9 +26,11 @@
 @end
 
 @implementation RNTableView {
+    RCTBridge *_bridge;
     RCTEventDispatcher *_eventDispatcher;
     NSArray *_items;
     NSMutableArray *_cells;
+    NSString *_reactModuleCellReuseIndentifier;
 }
 
 -(void)setEditing:(BOOL)editing {
@@ -66,11 +69,12 @@
     }
 }
 
-- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher
+- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher bridge:(RCTBridge*)bridge
 {
     RCTAssertParam(eventDispatcher);
     
     if ((self = [super initWithFrame:CGRectZero])) {
+        _bridge = bridge;
         _eventDispatcher = eventDispatcher;
         _cellHeight = 44;
         _cells = [NSMutableArray array];
@@ -148,6 +152,8 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
     _tableView.tableHeaderView = view;
     _tableView.tableFooterView = view;
     _tableView.separatorStyle = self.separatorStyle;
+    _reactModuleCellReuseIndentifier = @"ReactModuleCell";
+    [_tableView registerClass:[RNReactModuleCell class] forCellReuseIdentifier:_reactModuleCellReuseIndentifier];
     [self addSubview:_tableView];
 }
 - (void)tableView:(UITableView *)tableView willDisplayFooterView:(nonnull UIView *)view forSection:(NSInteger)section {
@@ -279,6 +285,7 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
                 if(selectedIndex == -1)
                     selectedIndex = [items count];
                 itemData[@"selected"] = @YES;
+                
                 found = YES;
             }
             [items addObject:itemData];
@@ -312,20 +319,35 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
     }
     return count;
 }
+
+-(UITableViewCell*)setupReactModuleCell:(UITableView *)tableView data:(NSDictionary*)data indexPath:(NSIndexPath *)indexPath {
+    RNReactModuleCell *cell = [tableView dequeueReusableCellWithIdentifier:_reactModuleCellReuseIndentifier];
+    if (cell == nil) {
+        cell = [[RNReactModuleCell alloc] initWithStyle:self.tableViewCellStyle reuseIdentifier:_reactModuleCellReuseIndentifier bridge: _bridge data:data indexPath:indexPath reactModule:_reactModuleForCell];
+    } else {
+        [cell setUpAndConfigure:data bridge:_bridge indexPath:indexPath reactModule:_reactModuleForCell];
+    }
+    return cell;
+}
+
 -(UITableViewCell* )tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell"];
+    UITableViewCell *cell = nil;
     NSDictionary *item = [self dataForRow:indexPath.item section:indexPath.section];
     
     // check if it is standard cell or user-defined UI
-    if (![self hasCustomCells:indexPath.section]){
+    if ([self hasCustomCells:indexPath.section]){
+        cell = ((RNCellView *)_cells[indexPath.section][indexPath.row]).tableViewCell;
+    } else if (self.reactModuleForCell != nil && ![self.reactModuleForCell isEqualToString:@""]) {
+        cell = [self setupReactModuleCell:tableView data:item indexPath:indexPath];
+    } else {
+        cell = [tableView dequeueReusableCellWithIdentifier:@"Cell"];
         if (cell == nil) {
             cell = [[UITableViewCell alloc] initWithStyle:self.tableViewCellStyle reuseIdentifier:@"Cell"];
         }
         cell.textLabel.text = item[@"label"];
         cell.detailTextLabel.text = item[@"detail"];
-    } else {
-        cell = ((RNCellView *)_cells[indexPath.section][indexPath.row]).tableViewCell;
     }
+    
     if (item[@"selected"] && [item[@"selected"] intValue]){
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
     } else if ([item[@"arrow"] intValue]) {
@@ -354,7 +376,8 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
 
 -(CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
     if (![self hasCustomCells:indexPath.section]){
-        return _cellHeight;
+        NSNumber *styleHeight = _sections[indexPath.section][@"items"][indexPath.row][@"height"];
+        return styleHeight.floatValue ?: _cellHeight;
     } else {
         RNCellView *cell = (RNCellView *)_cells[indexPath.section][indexPath.row];
         CGFloat height =  cell.componentHeight;

--- a/RNTableView/RNTableViewManager.m
+++ b/RNTableView/RNTableViewManager.m
@@ -10,6 +10,7 @@
 #import "RNTableView.h"
 #import "RCTBridge.h"
 #import "RCTConvert.h"
+#import "RCTUIManager.h"
 
 @implementation RNTableViewManager
 
@@ -154,6 +155,18 @@ RCT_CUSTOM_VIEW_PROPERTY(footerFontFamily, NSString, RNTableView)
     view.footerFont = [RCTConvert UIFont:view.footerFont withFamily:json ?: defaultView.font.familyName];
 }
 
+RCT_EXPORT_METHOD(reloadData:(nonnull NSNumber *)reactTag)
+{
+    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+        UIView *view = [uiManager viewForReactTag:reactTag];
+        for (UIView *subview in view.subviews) {
+            if ([subview isKindOfClass:[RNTableView class]]) {
+                [((RNTableView *)subview).tableView reloadData];
+                return;
+            }
+        }
+    }];
+}
 //
 //- (NSDictionary *)constantsToExport
 //{

--- a/RNTableView/RNTableViewManager.m
+++ b/RNTableView/RNTableViewManager.m
@@ -16,7 +16,7 @@
 RCT_EXPORT_MODULE()
 - (UIView *)view
 {
-    return [[RNTableView alloc] initWithEventDispatcher:self.bridge.eventDispatcher];
+    return [[RNTableView alloc] initWithEventDispatcher:self.bridge.eventDispatcher bridge:self.bridge];
 }
 
 RCT_EXPORT_VIEW_PROPERTY(sections, NSArray)
@@ -54,6 +54,11 @@ RCT_CUSTOM_VIEW_PROPERTY(tableViewCellStyle, UITableViewStyle, RNTableView) {
 
 RCT_CUSTOM_VIEW_PROPERTY(tableViewCellEditingStyle, UITableViewCellEditingStyle, RNTableView) {
     [view setTableViewCellEditingStyle:[RCTConvert NSInteger:json]];
+}
+
+/*Each cell is a separate app, multiple cells share the app/module name*/
+RCT_CUSTOM_VIEW_PROPERTY(reactModuleForCell, NSString*, RNTableView) {
+    [view setReactModuleForCell:[RCTConvert NSString:json]];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(contentInset, UIEdgeInsets, RNTableView) {

--- a/examples/TableViewDemo/index.ios.js
+++ b/examples/TableViewDemo/index.ios.js
@@ -75,6 +75,8 @@ class Example3 extends React.Component {
     render(){
         return (
             <TableView style={{flex:1}}
+                       allowsToggle={true}
+                       allowsMultipleSelection={true}
                        tableViewStyle={TableView.Consts.Style.Grouped}
                        tableViewCellStyle={TableView.Consts.CellStyle.Subtitle}
                        onPress={(event) => alert(JSON.stringify(event))}>

--- a/examples/TableViewDemo/index.ios.js
+++ b/examples/TableViewDemo/index.ios.js
@@ -8,6 +8,7 @@ var Item = TableView.Item;
 var Cell = TableView.Cell;
 var {Actions, Router, Route, Schema, Animations} = require('react-native-router-flux');
 var NavigationBar = require('react-native-navbar');
+var Firebase = require('firebase');
 
 class NavBar extends React.Component {
     render(){
@@ -74,8 +75,6 @@ class Example3 extends React.Component {
     render(){
         return (
             <TableView style={{flex:1}}
-                       allowsToggle={true}
-                       allowsMultipleSelection={true}
                        tableViewStyle={TableView.Consts.Style.Grouped}
                        tableViewCellStyle={TableView.Consts.CellStyle.Subtitle}
                        onPress={(event) => alert(JSON.stringify(event))}>
@@ -112,6 +111,127 @@ class Example3 extends React.Component {
     }
 }
 
+//Similar to example 2 but use "TableViewExampleCell" reusable cells
+class ReusableCellExample1 extends React.Component {
+    // list spanish provinces and add 'All states' item at the beginning
+    render() {
+        var country = "ES";
+        return (
+            <TableView selectedValue="" reactModuleForCell="TableViewExampleCell" style={{flex:1}} json="states" filter={`country=='${country}'`}
+                       tableViewCellStyle={TableView.Consts.CellStyle.Subtitle}
+                       onPress={(event) => alert(JSON.stringify(event))}>
+                <Item value="">All states</Item>
+            </TableView>
+        );
+    }
+}
+
+class ReusableCellExample2 extends React.Component {
+    render(){
+        var numAdditionaItems = 1000;
+        var moreItems = [];
+        for (var i = 0; i < numAdditionaItems; ++i) {
+            moreItems.push(i);
+        }
+        return (
+            <TableView reactModuleForCell="TableViewExampleCell" style={{flex:1}}
+                       allowsToggle={true}
+                       allowsMultipleSelection={true}
+                       tableViewStyle={TableView.Consts.Style.Grouped}
+                       onPress={(event) => alert(JSON.stringify(event))}>
+                <Section label="Section 1" arrow={true}>
+                    <Item>Item 1</Item>
+                    <Item>Item 2</Item>
+                    <Item>Item 3</Item>
+                    <Item backgroundColor="gray" height={44}>Item 4</Item>
+                    <Item>Item 5</Item>
+                    <Item>Item 6</Item>
+                    <Item>Item 7</Item>
+                    <Item>Item 8</Item>
+                    <Item>Item 9</Item>
+                    <Item backgroundColor="red" height={200}>Item 10</Item>
+                    <Item>Item 11</Item>
+                    <Item>Item 12</Item>
+                    <Item>Item 13</Item>
+                    <Item>Item 14</Item>
+                    <Item>Item 15</Item>
+                    <Item>Item 16</Item>
+                </Section>
+                <Section label="Section 2" arrow={false}>
+                    <Item>Item 1</Item>
+                    <Item>Item 2</Item>
+                    <Item>Item 3</Item>
+                </Section>
+                <Section label="Section 3" arrow={true}>
+                    <Item>Item 1</Item>
+                    <Item>Item 2</Item>
+                    <Item>Item 3</Item>
+                </Section>
+                <Section label={"large section - "+numAdditionaItems+" items"}>
+                    {moreItems.map((i)=><Item key={i+1}>{i+1}</Item>)}
+                </Section>
+            </TableView>
+        );
+    }
+}
+
+class FirebaseExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {data:null};
+        this.reactCellModule = "DinosaurCellExample";
+        this.firebaseLocation = "https://dinosaur-facts.firebaseio.com/dinosaurs";
+        this.propPrefix = "dinosaur";
+    }
+    componentDidMount() {
+        var dinData = null;
+        var self = this;
+        this.ref = new Firebase(this.firebaseLocation);
+        this.ref.on('value', function(snapshot) {
+            self.setState({data:snapshot.val()});
+        });
+    }
+    componentWillUnmount() {
+        this.ref.off();
+    }
+    renderItem(itemData, key, index) {
+        //TODO passing itemData={itemData} doesn't seem to work... so pass all data props with a prefix to make sure they don't clash
+        //with other <Item> props
+        var item = {};
+        Object.keys(itemData||{}).forEach(k => {
+           item[this.propPrefix+k] = itemData[k];
+        });
+        item[this.propPrefix+"key"] = key;
+
+        //concat all key-val's into one string
+        var label = Object.keys(itemData).map((k)=>k+":"+itemData[k]).join(",");
+
+        return (<Item {...item} height={140} backgroundColor={index%2==0?"white":"grey"} key={key} label={label}></Item>);
+    }
+    render() {
+        var data = this.state.data;
+        if (!data) {
+            return <Text style={{height:580}}>NO DATA</Text>
+        }
+
+        var self = this;
+        var items = Object.keys(data).map((key,index)=>self.renderItem(data[key], key, index));
+
+        return (
+            <View style={{flex:1}}>
+                <Text value="">All Items</Text>
+                <TableView style={{flex:1}} reactModuleForCell={this.reactCellModule}
+                           tableViewCellStyle={TableView.Consts.CellStyle.Default}
+                           onPress={(event) => alert(JSON.stringify(event))}>
+                    <Section arrow={true}>
+                        {items}
+                    </Section>
+                </TableView>
+            </View>
+        );
+    }
+}
+
 class Edit extends React.Component {
     constructor(props){
         super(props);
@@ -124,22 +244,66 @@ class Edit extends React.Component {
                 <NavBar {...this.props} nextTitle={this.state.editing ? "Done" : "Edit"}
                                         onNext={()=>self.setState({editing: !self.state.editing})}/>
                 <TableView style={{flex:1}} editing={this.state.editing}
-                       onPress={(event) => alert(JSON.stringify(event))} onChange={(event) => alert("CHANGED:"+JSON.stringify(event))}>
-                <Section canMove={true} canEdit={true}>
-                    <Item canEdit={false}>Item 1</Item>
-                    <Item>Item 2</Item>
-                    <Item>Item 3</Item>
-                    <Item>Item 4</Item>
-                    <Item>Item 5</Item>
-                    <Item>Item 6</Item>
-                    <Item>Item 7</Item>
-                    <Item>Item 8</Item>
-                </Section>
-            </TableView>
-                </View>
+                           onPress={(event) => alert(JSON.stringify(event))} onChange={(event) => alert("CHANGED:"+JSON.stringify(event))}>
+                    <Section canMove={true} canEdit={true}>
+                        <Item canEdit={false}>Item 1</Item>
+                        <Item>Item 2</Item>
+                        <Item>Item 3</Item>
+                        <Item>Item 4</Item>
+                        <Item>Item 5</Item>
+                        <Item>Item 6</Item>
+                        <Item>Item 7</Item>
+                        <Item>Item 8</Item>
+                    </Section>
+                </TableView>
+            </View>
         );
     }
 }
+class ListViewExample extends React.Component {
+    constructor(props){
+        super(props);
+        this.numAdditionaItems = 1000;
+        this.data = {};
+        for (var i = 0; i < this.numAdditionaItems; ++i) {
+            this.data[i] = i;
+        }
+        this.state = {dataSource: new React.ListView.DataSource({
+            rowHasChanged: (r1, r2) => r1 !== r2
+        })};
+    }
+    render() {
+        const data = this.data;
+        return (
+            <React.ListView
+                dataSource={this.state.dataSource.cloneWithRows(Object.keys(data))}
+                renderRow={(k) => <Text onPress={(e)=>alert("item:"+k+", "+data[k])}> data: {data[k]}</Text>}
+                />
+        );
+    }
+}
+
+class LargeTableExample extends React.Component {
+    render() {
+        var numAdditionaItems = 1000;
+        var items = [];
+        for (var i = 0; i < numAdditionaItems; ++i) {
+            items.push(i);
+        }
+        return (
+            <TableView reactModuleForCell="TableViewExampleCell" style={{flex:1}}
+                           allowsToggle={true}
+                           allowsMultipleSelection={true}
+                           tableViewStyle={TableView.Consts.Style.Grouped}
+                           onPress={(event) => alert(JSON.stringify(event))}>
+                <Section label={"large section - "+numAdditionaItems+" items"} arrow={true}>
+                    {items.map((i)=><Item key={i+1}>{i+1}</Item>)}
+                </Section>
+            </TableView>
+        );
+    }
+}
+
 
 class Launch extends React.Component {
     constructor(props) {
@@ -158,6 +322,11 @@ class Launch extends React.Component {
                     <Item onPress={Actions.example2}>Example with app bundle JSON data</Item>
                     <Item onPress={Actions.example3}>Example with multiple sections</Item>
                     <Item onPress={Actions.edit}>Example with editing mode</Item>
+                    <Item onPress={Actions.example4}>Reusable Cell Example 1</Item>
+                    <Item onPress={Actions.example5}>Reusable Custom Cells</Item>
+                    <Item onPress={Actions.example6}>Firebase Example</Item>
+                    <Item onPress={Actions.example7}>Large ListView (scroll memory growth)</Item>
+                    <Item onPress={Actions.example8}>Reusable Large TableView Example</Item>
                 </Section>
             </TableView>
         );
@@ -174,10 +343,67 @@ class TableViewExample extends React.Component {
                 <Route name="example2" component={Example2} title="Example 2"/>
                 <Route name="example3" component={Example3} title="Example 3"/>
                 <Route name="edit" component={Edit} title="Edit Table" hideNavBar={true}/>
+                <Route name="example4" component={ReusableCellExample1} title="Reusable Cell Example 1"/>
+                <Route name="example5" component={ReusableCellExample2} title="Reusable Custom Cells"/>
+                <Route name="example6" component={FirebaseExample} title="Firebase Example"/>
+                <Route name="example7" component={ListViewExample} title="Large ListView Example"/>
+                <Route name="example8" component={LargeTableExample} title="Reusable Large TableView Example"/>
             </Router>
 
         );
     }
 }
 
+//Should be pure... setState on top-level component doesn't seem to work
+class TableViewExampleCell extends React.Component {
+    render(){
+        var style = {};
+        //cell height is passed from <Item> child of tableview and native code passes it back up to javascript in "app params" for the cell.
+        //This way our component will fill the full native table cell height.
+        if (this.props.data.height !== undefined) {
+            style.height = this.props.data.height;
+        }
+        if (this.props.data.backgroundColor !== undefined) {
+            style.backgroundColor = this.props.data.backgroundColor;
+        }
+        return (<View style={style}><Text>section:{this.props.section},row:{this.props.row},label:{this.props.data.label}</Text></View>);
+    }
+}
+
+//Should be pure... setState on top-level component doesn't seem to work
+class DinosaurCellExample extends React.Component {
+    yearsAgoInMil(num) {
+        return ((-1 * num)/1000000)+" million years ago";
+    }
+    render(){
+        var style = {};
+        //cell height is passed from <Item> child of tableview and native code passes it back up to javascript in "app params" for the cell.
+        //This way our component will fill the full native table cell height.
+        if (this.props.data.height !== undefined) {
+            style.height = this.props.data.height;
+        }
+        if (this.props.data.backgroundColor !== undefined) {
+            style.backgroundColor = this.props.data.backgroundColor;
+        }
+        style.borderColor = "grey";
+        style.borderRadius = 0.02;
+
+        var appeared = this.yearsAgoInMil(this.props.data.dinosaurappeared);
+        var vanished = this.yearsAgoInMil(this.props.data.dinosaurvanished);
+        return (<View style={style}>
+            <Text style={{backgroundColor:"#4fa2c3"}}>Name: {this.props.data.dinosaurkey}</Text>
+            <Text>Order:{this.props.data.dinosaurorder}</Text>
+            <Text>Appeared: {appeared}</Text>
+            <Text style={{backgroundColor:"lightgrey"}}>Vanished: {vanished}</Text>
+            <Text>Height: {this.props.data.dinosaurheight}</Text>
+            <Text>Length: {this.props.data.dinosaurlength}</Text>
+            <Text>Weight: {this.props.data.dinosaurweight}</Text>
+        </View>);
+    }
+}
+
+
+
 AppRegistry.registerComponent('TableViewExample', () => TableViewExample);
+AppRegistry.registerComponent('TableViewExampleCell', () => TableViewExampleCell);
+AppRegistry.registerComponent('DinosaurCellExample', () => DinosaurCellExample);

--- a/examples/TableViewDemo/index.ios.js
+++ b/examples/TableViewDemo/index.ios.js
@@ -257,9 +257,12 @@ class CustomEditableExample extends React.Component {
             var newData = (this.dataItemKeysBeingEdited || []).map(itemKey=>self.state.data[itemKey]);
             this.dataItemKeysBeingEdited = null;
 
-            this.setState({editing: false}, function() {
+            this.setState({editing: false, data: newData}, function() {
                 //Simulate saving data remotely and getting a data-changed callback
-                setTimeout(()=>self.onExternalData(newData), 2);
+                setTimeout(()=> {
+                    self.onExternalData(newData);
+                    this.setState({editing: false});
+                });
             });
         } else {
             //Start editing - save snapshot of data
@@ -277,7 +280,7 @@ class CustomEditableExample extends React.Component {
 
         //The last data we rendered with hasn't changed, but native side *displayed* data has changed
         //due to local editing. Need to force to re-render with javascript data.
-        this.setState({editing: false, data: {...data,'___fake___':true}}, function() {
+        this.setState({editing: false, data: {...data,'___fake___':"1"}}, function() {
             self.setState({editing: false, data: data});
         })
     }

--- a/examples/TableViewDemo/index.ios.js
+++ b/examples/TableViewDemo/index.ios.js
@@ -359,11 +359,13 @@ class TableViewExample extends React.Component {
 //Should be pure... setState on top-level component doesn't seem to work
 class TableViewExampleCell extends React.Component {
     render(){
-        var style = {};
+        var style = {borderColor:"#aaaaaa", borderWidth:1, borderRadius:3};
         //cell height is passed from <Item> child of tableview and native code passes it back up to javascript in "app params" for the cell.
         //This way our component will fill the full native table cell height.
         if (this.props.data.height !== undefined) {
             style.height = this.props.data.height;
+        } else {
+            style.flex = 1;
         }
         if (this.props.data.backgroundColor !== undefined) {
             style.backgroundColor = this.props.data.backgroundColor;

--- a/examples/TableViewDemo/index.ios.js
+++ b/examples/TableViewDemo/index.ios.js
@@ -259,10 +259,7 @@ class CustomEditableExample extends React.Component {
 
             this.setState({editing: false, data: newData}, function() {
                 //Simulate saving data remotely and getting a data-changed callback
-                setTimeout(()=> {
-                    self.onExternalData(newData);
-                    this.setState({editing: false});
-                });
+                setTimeout(()=> self.onExternalData(newData), 2);
             });
         } else {
             //Start editing - save snapshot of data

--- a/examples/TableViewDemo/package.json
+++ b/examples/TableViewDemo/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "firebase": "^2.4.0",
     "react-native": "^0.19.0",
-    "react-native-navbar": "^0.8.2",
+    "react-native-navbar": "^1.2.0",
     "react-native-router-flux": "^2.1.8",
     "react-native-tableview": "1.4.2",
     "react-native-tabs": "^0.1.10"

--- a/examples/TableViewDemo/package.json
+++ b/examples/TableViewDemo/package.json
@@ -6,9 +6,11 @@
     "start": "node_modules/react-native/packager/packager.sh"
   },
   "dependencies": {
-    "react-native": "^0.14.2",
+    "firebase": "^2.4.0",
+    "react-native": "^0.19.0",
     "react-native-navbar": "^0.8.2",
-    "react-native-router-flux": "^0.3.0",
-    "react-native-tableview": "1.4.1"
+    "react-native-router-flux": "^2.1.8",
+    "react-native-tableview": "1.4.2",
+    "react-native-tabs": "^0.1.10"
   }
 }


### PR DESCRIPTION
This is not really necessary but I did the work (then didn't end up using it) so here it is in case it might be valuable to someone.

I'm not super experienced with the bridge so not sure what the best way to expose a method is. The way I wrote it works from JS like so:

```
var RNTableViewManager = React.NativeModules.RNTableViewManager;

reloadTableView() {
  RNTableViewManager.reloadData(React.findNodeHandle(this.refs.tableView))
}
```
